### PR TITLE
wrong routing when reloading page

### DIFF
--- a/Angular2WebpackVisualStudio/src/Angular2WebpackVisualStudio/angular2App/index.html
+++ b/Angular2WebpackVisualStudio/src/Angular2WebpackVisualStudio/angular2App/index.html
@@ -1,7 +1,7 @@
 ﻿<!doctype html>
 <html>
 <head>
-    <base href="./">
+    <base href="/">
 
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
When I have href="./" as the base my routing is not working as expected. If I refresh the page at localhost:5000/page/1 my "root" url will be "localhost:5000/page. When I removed the . everything works as I would expect.