### PR TITLE
Fix 404 error when refresh

### DIFF
--- a/Angular2WebpackVisualStudio/src/Angular2WebpackVisualStudio/Startup.cs
+++ b/Angular2WebpackVisualStudio/src/Angular2WebpackVisualStudio/Startup.cs
@@ -36,21 +36,6 @@ namespace Angular2WebpackVisualStudio
             loggerFactory.AddConsole(Configuration.GetSection("Logging"));
             loggerFactory.AddDebug();
 
-            var angularRoutes = new[] {
-                 "/home"
-             };
-
-            app.Use(async (context, next) =>
-            {
-                if (context.Request.Path.HasValue && null != angularRoutes.FirstOrDefault(
-                    (ar) => context.Request.Path.Value.StartsWith(ar, StringComparison.OrdinalIgnoreCase)))
-                {
-                    context.Request.Path = new PathString("/");
-                }
-
-                await next();
-            });
-
             app.UseDefaultFiles();
 
             app.UseStaticFiles();

--- a/Angular2WebpackVisualStudio/src/Angular2WebpackVisualStudio/angular2App/app/app.module.ts
+++ b/Angular2WebpackVisualStudio/src/Angular2WebpackVisualStudio/angular2App/app/app.module.ts
@@ -1,5 +1,5 @@
 import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { CommonModule, HashLocationStrategy, LocationStrategy } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { HttpModule } from '@angular/http';
@@ -28,7 +28,8 @@ import { TestDataService } from './services/testDataService';
     ],
     providers: [
         TestDataService,
-        Configuration
+        Configuration,
+        { provide: LocationStrategy, useClass: HashLocationStrategy }
     ],
     bootstrap: [AppComponent],
 })


### PR DESCRIPTION
the idea is to use HashLocationStrategy  as LocationStrategy and changes are based on [Angular 2 : 404 error occur when i refresh through Browser](http://stackoverflow.com/q/35284988/2833802) SO.

Remark: removing in `Startup` class is not related directly to fix, but this logic will be unuseful if add HashLocationStrategy.